### PR TITLE
MacOS support in 3.0 branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,7 @@ Thumbs.db
 .sconsign.dblite
 godot_project/.import/
 godot_project/lib/gdsqlite/*.lib
-lib/gdsqlite*.lib
+godot_project/lib/gdsqlite/*.dylib
+lib/gdsqlite*.li
+lib/*.dylib
 vsproj/

--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ A [SQLite](https://www.sqlite.org/) wrapper for Godot Engine 3.0
 
 Download latest [release](https://github.com/khairul169/gdsqlite-native/releases) of this module and uncompress it on your project directory.
 
+## Compiling for MacOS
+
+1. Clone the repository, `cd` into the directory
+2. `git submodule init`
+3. `git submodule update`
+4. `scons platform=osx`
+5. `gdsqlite-native/godot_project/lib/gdsqlite/libgdsqlite.64.dylib` is generated. 
+6. You now can run the test project in Godot 3.0 (tested on MacOS 10.14 in Godot 3.0.6).
+
 ## Example usage
 
 - [SQL Queries](https://github.com/khairul169/gdsqlite-native/blob/master/godot_project/examples/sql_queries.gd)

--- a/SConstruct
+++ b/SConstruct
@@ -30,6 +30,10 @@ if platform == 'windows':
 		env['PDB']='${TARGET.base}.pdb'
 		env.Append(CCFLAGS = ['-EHsc', '/DEBUG', '-D_DEBUG', '/MDd'])
 
+if platform == 'osx':
+	env.Append(CCFLAGS = ['-g','-O3', '-arch', 'x86_64'])
+	env.Append(LINKFLAGS = ['-arch', 'x86_64'])
+
 # Source lists
 sources = [
 	"src/gdsqlite.c",

--- a/godot_project/lib/gdsqlite/gdsqlite.gdnlib
+++ b/godot_project/lib/gdsqlite/gdsqlite.gdnlib
@@ -7,6 +7,7 @@ reloadable=false
 
 [entry]
 
+OSX.64="res://lib/gdsqlite/libgdsqlite.64.dylib"
 Windows.64="res://lib/gdsqlite/gdsqlite.64.dll"
 Windows.32="res://lib/gdsqlite/gdsqlite.32.dll"
 X11.64="res://lib/gdsqlite/libgdsqlite.64.so"
@@ -15,6 +16,7 @@ Server="res://lib/gdsqlite/libgdsqlite.64.so"
 
 [dependencies]
 
+OSX.64=[  ]
 Windows.64=[  ]
 Windows.32=[  ]
 X11.64=[  ]


### PR DESCRIPTION
This adds support for building the plugin for MacOS and some instructions in the README for how to do so (in the 3.0 branch).