### PR TITLE
Added backup wrapper method to copy SQLite databases

### DIFF
--- a/src/gdsqlite.cpp
+++ b/src/gdsqlite.cpp
@@ -88,6 +88,24 @@ void SQLite::close() {
 	}
 }
 
+bool SQLite::backup(SQLite* other) {
+	// Initialize backup
+	sqlite3_backup *backup_data = sqlite3_backup_init(other->db, "main", db, "main");
+	
+	// Check that initialize succeeded
+	if(!backup_data)
+		return false;
+	
+	// Copy all pages
+	int result = sqlite3_backup_step(backup_data, -1);
+	
+	if(result != SQLITE_DONE)
+		Godot::print("SQLite backup failed!");
+	
+	sqlite3_backup_finish(backup_data);
+	return result == SQLITE_DONE;
+}
+
 sqlite3_stmt* SQLite::prepare(const char* query) {
 	// Get database pointer
 	sqlite3 *dbs = get_handler();
@@ -221,4 +239,5 @@ void SQLite::_register_methods() {
 	register_method("close", &SQLite::close);
 	register_method("fetch_array", &SQLite::fetch_array);
 	register_method("fetch_assoc", &SQLite::fetch_assoc);
+	register_method("backup", &SQLite::backup);
 }

--- a/src/gdsqlite.hpp
+++ b/src/gdsqlite.hpp
@@ -44,6 +44,7 @@ namespace godot {
 		bool open(String path);
 		bool open_buffered(String name, PoolByteArray buffers, int64_t size);
 		void close();
+		bool backup(SQLite *other);
 
 		bool query(String statement);
 		Array fetch_array(String statement);


### PR DESCRIPTION
This PR adds the method `backup(SQLite other)`, which copies the source database's content to `other` using SQLite's backup API. This is very helpful for copying file databases to memory, or copying memory databases to files.

This method has been tested on Windows 10 64-bit with Godot commit 3333166b070dea0e1d1255a9f9c4cfefe0ec32e5