### PR TITLE
Fixed Windows-only method calls

### DIFF
--- a/demo/lib/gdsqlite/library.tres
+++ b/demo/lib/gdsqlite/library.tres
@@ -9,6 +9,10 @@ symbol_prefix = "godot_"
 reloadable = true
 entry/Windows.64 = "res://lib/gdsqlite/gdsqlite.64.dll"
 entry/Windows.32 = "res://lib/gdsqlite/gdsqlite.32.dll"
+entry/X11.64 = "res://lib/gdsqlite/libgdsqlite.64.so"
+entry/X11.32 = "res://lib/gdsqlite/libgdsqlite.32.so"
 dependency/Windows.64 = [  ]
 dependency/Windows.32 = [  ]
+dependency/X11.64 = [  ]
+dependency/X11.32 = [  ]
 

--- a/thirdparty/sqlite/spmemvfs.c
+++ b/thirdparty/sqlite/spmemvfs.c
@@ -26,6 +26,8 @@
 * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#pragma warning(disable: 4996) // Fixes "unsafe" warnings for strdup and strncpy
+
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -292,7 +294,7 @@ int spmemvfsOpen( sqlite3_vfs * vfs, const char * path, sqlite3_file * file, int
 	memfile->base.pMethods = &g_spmemfile_io_memthods;
 	memfile->flags = flags;
 
-	memfile->path = _strdup( path );
+	memfile->path = strdup( path );
 
 	if( SQLITE_OPEN_MAIN_DB & memfile->flags ) {
 		memfile->mem = memvfs->cb.load( memvfs->cb.arg, path );
@@ -319,7 +321,7 @@ int spmemvfsAccess( sqlite3_vfs * vfs, const char * path, int flags, int * resul
 
 int spmemvfsFullPathname( sqlite3_vfs * vfs, const char * path, int len, char * fullpath )
 {
-	strncpy_s( fullpath, strlen(path) + 1, path, len );
+	strncpy( fullpath, path, len );
 	fullpath[ len - 1 ] = '\0';
 
 	return SQLITE_OK;
@@ -498,7 +500,7 @@ int spmemvfs_open_db( spmemvfs_db_t * db, const char * path, spmembuffer_t * mem
 	memset( db, 0, sizeof( spmemvfs_db_t ) );
 
 	iter = (spmembuffer_link_t*)calloc( sizeof( spmembuffer_link_t ), 1 );
-	iter->path = _strdup( path );
+	iter->path = strdup( path );
 	iter->mem = mem;
 
 	sqlite3_mutex_enter( g_spmemvfs_env->mutex );


### PR DESCRIPTION
`spmemvfs.c` currently calls two methods that are only available in Microsoft's VS compiler, `strncpy_s` and `_strdup`:
https://github.com/khairul169/gdsqlite-native/blob/264af86a68b70ec5f8d72dfd3f603db8f5b64742/thirdparty/sqlite/spmemvfs.c#L295
https://github.com/khairul169/gdsqlite-native/blob/264af86a68b70ec5f8d72dfd3f603db8f5b64742/thirdparty/sqlite/spmemvfs.c#L322
https://github.com/khairul169/gdsqlite-native/blob/264af86a68b70ec5f8d72dfd3f603db8f5b64742/thirdparty/sqlite/spmemvfs.c#L501

I've replaced these lines with `strncpy` and `strdup` respectively, and have added `#pragma warning(disable:4996)` to the file to prevent Visual Studio from throwing errors about "insecure" methods.

I have also added links to the compiled X11 binaries into `library.tres`.

This PR has been tested on Windows 10 64-bit and Ubuntu 18.04 with Godot commit 42ed26d