### PR TITLE
Added functions for parameterized queries

### DIFF
--- a/src/gdsqlite.hpp
+++ b/src/gdsqlite.hpp
@@ -46,12 +46,15 @@ namespace godot {
 		void close();
 
 		bool query(String statement);
+		bool query_with_args(String statement, PoolStringArray args);
 		Array fetch_array(String statement);
+		Array fetch_array_with_args(String statement, PoolStringArray args);
 		Array fetch_assoc(String statement);
+		Array fetch_assoc_with_args(String statement, PoolStringArray args);
 
 	private:
 		sqlite3_stmt* prepare(const char* statement);
-		Array fetch_rows(String query, int result_type = RESULT_BOTH);
+		Array fetch_rows(String query, PoolStringArray args, int result_type = RESULT_BOTH);
 		Dictionary parse_row(sqlite3_stmt *stmt, int result_type);
 		sqlite3* get_handler() { return (memory_read ? p_db.handle : db); }
 	};


### PR DESCRIPTION
This pull request adds `query_with_args`, `fetch_array_with_args`, and `fetch_assoc_with_args`. These functions use parameter binding and help defend against SQL injection attacks. Each of these takes an additional `PoolStringArray`. These can be called like so:
```
db.query_with_args("INSERT INTO potion VALUES(?, ?, ?)", ["Jeff's Frikkin' Tasty Heals", 50, 25])
```

Each function will fail if the amount of arguments passed does not match the amount of arguments in the query. This pull request _should_ maintain backwards compatibility with code written using the non-parameterized functions.

Tested on Windows 10 Home 64-bit on Godot 3.1 stable. Closes #28 