### PR TITLE
Added build for Android

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,5 +1,6 @@
 #!python
 import os
+import sys
 
 # Environment
 env = Environment(ENV = os.environ);
@@ -42,8 +43,6 @@ if platform == 'windows':
 	else:
 		env.Append(CCFLAGS = ['-D_WIN32', '/EHsc', '/O2', '/MD' ])
 
-godotcpp_lib += '.' + platform + '.' + target + '.' + bits
-
 # If platform is OSX
 if platform == 'osx':
 	# If using Clang
@@ -55,10 +54,93 @@ if platform == 'osx':
 	env.Append(LINKFLAGS = [ '-arch', 'x86_64', '-framework', 'Cocoa', '-Wl,-undefined,dynamic_lookup' ])
 	env.Append(RPATH=env.Literal("\\$$ORIGIN"))
 
-if bits == '64':
-	output += '.64';
-else:
-	output += '.32';
+if platform == 'android':
+	android_arch = ARGUMENTS.get('android_arch', 'armv7')
+	# Validate arch
+	if android_arch not in ['armv7', 'arm64v8', 'x86', 'x86_64']:
+		print("ERR: Invalid Android architecture \"", android_arch, "\"\nAllowed values: [armv7, arm64v8, x86, x86_64]")
+		Exit(1)
+	
+	ndk_platform = int(ARGUMENTS.get('ndk_platform', 18 if android_arch in ['armv7', 'x86'] else 21))
+	# Validate platform
+	if ndk_platform < 21 and android_arch in ['arm64v8', 'x86_64']:
+		print("WARN: ", android_arch, " architecture requires at least ndk_platform=21; settings ndk_platform=21")
+		ndk_platform = 21
+	
+	ndk_root = ARGUMENTS.get('ANDROID_NDK_ROOT', os.environ.get('ANDROID_NDK_ROOT', None))
+	# Validate NDK
+	if not ndk_root:
+		print("ERR: Could not find Android NDK path. Please install the Android NDK and set ANDROID_NDK_ROOT to the path to your installation.")
+		Exit(1)
+	
+	# Get host platform
+	if sys.platform.startswith("win"):
+		host_platform = "windows"
+		env = env.Clone(tools=['mingw'])
+	elif sys.platform.startswith("linux"):
+		host_platform = "linux"
+	elif sys.platform.startswith("darwin"):
+		host_platform = "darwin" # osx
+	else:
+		print("ERR: Could not detect host platform")
+		print("sys.platform: ", sys.platform);
+		Exit(1);
+	
+	toolchain = ndk_root + "/toolchains/llvm/prebuilt/" + host_platform
+	import platform as pltfm
+	if host_platform != 'windows' or pltfm.machine().endswith('64'):
+		toolchain += '-x86_64'
+	toolchain += "/bin/"
+
+	env['CXX'] = toolchain + "clang++"
+	env['CC'] = toolchain + "clang"
+
+	# Setup arch-specifics
+	if android_arch == 'armv7':
+		target_flags = ['-target', 'armv7a-linux-androideabi' + str(ndk_platform), '-march=armv7-a', '-mfpu=neon']
+		tool_prefix = "arm-linux-androideabi"
+	elif android_arch == 'arm64v8':
+		target_flags = ['-target', 'aarch64-linux-android' + str(ndk_platform), '-march=armv8-a']
+		tool_prefix = "aarch64-linux-android"
+	elif android_arch == "x86":
+		target_flags = ['-target', 'i686-linux-android' + str(ndk_platform)]
+		if ndk_platform < 24:
+			env.Append(CCFLAGS=['-mstackrealign'])
+		tool_prefix = "i686-linux-android"
+	elif android_arch == "x86_64":
+		target_flags = ['-target', 'x86_64-linux-android' + str(ndk_platform)]
+		tool_prefix = "x86_64-linux-android"
+	env.Append(CCFLAGS=target_flags, LINKFLAGS=target_flags)
+	
+	env['LD'] = toolchain + tool_prefix + "-ld"
+	env['RANLIB'] = toolchain + tool_prefix + '-ranlib'
+	env['AR'] = toolchain + tool_prefix + '-ar'
+	env['AS'] = toolchain + tool_prefix + '-as'
+	env['LINK'] = env['CXX']
+	env.Append(CCFLAGS=['-fPIC'])
+	env.Append(LINKFLAGS=['-fPIC'])
+	env['SHLIBPREFIX'] = 'lib'
+	env['SHLIBSUFFIX'] = '.so'
+
+	def find_ixes_wrapper(self, paths, prefix, suffix): # Prevents bad linker flags
+		if prefix == 'LIBPREFIX' and suffix == 'LIBSUFFIX':
+			return False
+		else:
+			return self.old_ixes(paths, prefix, suffix)
+	
+	from types import MethodType
+	env.old_ixes = env.FindIxes
+	env.FindIxes = MethodType(find_ixes_wrapper, env)
+
+	output += '.' + android_arch
+
+godotcpp_lib += '.' + platform + '.' + target + '.' + (bits if platform != 'android' else android_arch)
+
+if platform != 'android':
+	if bits == '64':
+		output += '.64';
+	else:
+		output += '.32';
 
 # Include dir
 env.Append(CPPPATH=[
@@ -82,5 +164,8 @@ sources = [
 env.Append(LIBPATH=['thirdparty/godot_cpp/bin/']);
 env.Append(LIBS=[godotcpp_lib]);
 
-library = env.SharedLibrary(target=('bin/' + output), source=sources);
-Install('demo/lib/gdsqlite', source=library);
+library = env.SharedLibrary(target=('bin/' + output + env['SHLIBSUFFIX']), source=sources);
+if platform == 'android': # Fix non-existant outputs
+	Install('demo/lib/gdsqlite', source=File('bin/' + env['SHLIBPREFIX'] + output + env['SHLIBSUFFIX']))
+else:
+	Install('demo/lib/gdsqlite', source=library);

--- a/demo/lib/gdsqlite/library.tres
+++ b/demo/lib/gdsqlite/library.tres
@@ -1,13 +1,19 @@
 [gd_resource type="GDNativeLibrary" format=2]
 
 [resource]
-config_file = Object(ConfigFile,"script":null)
-
+entry/Android.armeabi-v7a = "res://lib/gdsqlite/libgdsqlite.armv7.so"
+entry/Android.arm64-v8a = "res://lib/gdsqlite/libgdsqlite.arm64v8.so"
+entry/Android.x86 = "res://lib/gdsqlite/libgdsqlite.x86.so"
+entry/Android.x86_64 = "res://lib/gdsqlite/libgdsqlite.x86_64.so"
 entry/OSX.64 = "res://lib/gdsqlite/libgdsqlite.64.dylib"
 entry/Windows.64 = "res://lib/gdsqlite/gdsqlite.64.dll"
 entry/Windows.32 = "res://lib/gdsqlite/gdsqlite.32.dll"
 entry/X11.64 = "res://lib/gdsqlite/libgdsqlite.64.so"
 entry/X11.32 = "res://lib/gdsqlite/libgdsqlite.32.so"
+dependency/Android.armeabi-v7a = [  ]
+dependency/Android.arm64-v8a = [  ]
+dependency/Android.x86 = [  ]
+dependency/Android.x86_64 = [  ]
 dependency/OSX.64 = [  ]
 dependency/Windows.64 = [  ]
 dependency/Windows.32 = [  ]


### PR DESCRIPTION
This commit adds the ability to build for Android platforms. For Android builds, a few new Scons options have been added:

- `android_arch` (Valid options: `armv7, arm64v8, x86, x86_64`)
    - The target Android architecture to build for
- `ndk_platform` (Valid range: `18-29`)
    - The Android API level to target. Defaults to 18 for 32-bit platforms, 21 for 64-bit platforms
- `ANDROID_NDK_ROOT`
    - The path to an NDK installation on your computer. By default, uses the system's environment variables to find this.

This commit also updates `godot-cpp` to master commit 123d9f0, which supports Android builds.

This commit was built on Windows 10 64-bit and Lubuntu Desktop 19.04.
Tested on a Samsung Galaxy S10E.
Closes #31

---
~~NOTE: While this commit technically does add Android support, the [Godot C++ bindings](https://github.com/godotnativetools/godot-cpp) themselves [do not support building for Android](https://github.com/GodotNativeTools/godot-cpp/pull/319) yet. I am currently [working with other developers](https://github.com/Jayanth-L/godot-cpp/pull/1) to bring Android compilation for godot-cpp, and when it is officially added, it will work fine with this commit.~~