### PR TITLE
Added BLOB data support, rewrote argument binding

### DIFF
--- a/src/gdsqlite.hpp
+++ b/src/gdsqlite.hpp
@@ -46,17 +46,18 @@ namespace godot {
 		void close();
 
 		bool query(String statement);
-		bool query_with_args(String statement, PoolStringArray args);
+		bool query_with_args(String statement, Array args);
 		Array fetch_array(String statement);
-		Array fetch_array_with_args(String statement, PoolStringArray args);
+		Array fetch_array_with_args(String statement, Array args);
 		Array fetch_assoc(String statement);
-		Array fetch_assoc_with_args(String statement, PoolStringArray args);
+		Array fetch_assoc_with_args(String statement, Array args);
 
 	private:
 		sqlite3_stmt* prepare(const char* statement);
-		Array fetch_rows(String query, PoolStringArray args, int result_type = RESULT_BOTH);
+		Array fetch_rows(String query, Array args, int result_type = RESULT_BOTH);
 		Dictionary parse_row(sqlite3_stmt *stmt, int result_type);
 		sqlite3* get_handler() { return (memory_read ? p_db.handle : db); }
+		bool bind_args(sqlite3_stmt *stmt, Array args);
 	};
 }
 #endif


### PR DESCRIPTION
This pull request changes how arguments are bound for queries, allowing for Variant types like PoolByteArrays to be bound to BLOB-type columns. It also adds the ability to retrieve BLOB types from databases as a PoolByteArray.

The side effect of this is that any `*_with_args` command will only accept an Array containing the following Variant types:
- Primitives (`int`, `float`, `bool`)
- Strings
- PoolByteArrays
- `null`
Any other Variant types passed will cause the query to fail.

This pull request has been tested on Windows 10 64-bit, using Godot 3.1.1 stable.

Closes #41.